### PR TITLE
Explicitly prefer brotli > gzip > deflate as encoding method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,9 @@ const status = require('statuses')
 const Stream = require('stream')
 const bytes = require('bytes')
 const zlib = require('zlib')
-const brotli = require('zlib').createBrotliCompress ? require('zlib').createBrotliCompress : require('iltorb').compressStream
+const brotli = require('zlib').createBrotliCompress
+    ? require('zlib').createBrotliCompress
+    : require('iltorb').compressStream
 
 /**
  * Encoding methods supported.
@@ -49,12 +51,16 @@ module.exports = (options = {}) => {
         if (!(ctx.compress === true || filter(ctx.response.type))) return
 
         // identity
-        const encoding = ctx.acceptsEncodings(
-            'gzip',
-            'deflate',
-            'identity',
-            'br'
-        )
+        let encoding = null
+        if (ctx.acceptsEncodings('br') === 'br') {
+            encoding = 'br'
+        } else if (ctx.acceptsEncodings('gzip') === 'gzip') {
+            encoding = 'gzip'
+        } else if (ctx.acceptsEncodings('deflate') === 'deflate') {
+            encoding = 'deflate'
+        } else {
+            encoding = ctx.acceptsEncodings('identity')
+        }
         if (!encoding)
             ctx.throw(406, 'supported encodings: gzip, deflate, identity, br')
         if (encoding === 'identity') return

--- a/test/index.js
+++ b/test/index.js
@@ -309,4 +309,32 @@ describe('Compress', () => {
                 done()
             })
     })
+
+    it('should prefer brotli over gzip as encoding method', done => {
+        const app = new Koa()
+
+        app.use(
+            compress({
+                threshold: 0
+            })
+        )
+
+        app.use((ctx, next) => {
+            ctx.type = 'text/plain'
+            ctx.body = 'asdf'
+        })
+
+        request(app.listen())
+            .get('/')
+            .set('Accept-Encoding', 'gzip, deflate, br')
+            .expect(200)
+            .buffer()
+            .end((err, res) => {
+                if (err) return done(err)
+
+                res.should.have.header('Content-Encoding', 'br')
+
+                done()
+            })
+    })
 })


### PR DESCRIPTION
This will fix brotli support on `gzip, deflate, br` accept-encoding header that currently browsers send to server.